### PR TITLE
add drupal core version "conflict" 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
+    },
+    "conflict": {
+        "drupal/core": "<9"
     }
 }


### PR DESCRIPTION
Add "conflict" to composer.json to prevent the 9.x version from being installed on drupal 8 projects.

The version requirement in `info.yml` prevents the 9.x version of this module from being **_enabled_** on d8 sites, but this change 🤞SHOULD🤞 prevent it from being composer-installed on d8 sites.

----
### To "test" 
Try requiring this module (either: without a version constraint, or with ^9) on a drupal 8 site -- it should succeed, even though it's actually incompatible:
```
composer require cubear/cwd_events
```
(or)
```
composer require cubear/cwd_events:^9
```

**THEN** try requiring this branch on a drupal 8 site -- it should fail:
```
composer require cubear/cwd_events:dev-d8-conflict
```

(And try running that same require command on a drupal 9 site -- but if you don't have one handy, know that I did it and it successfully installed this branch/version of the package.)